### PR TITLE
Update optd_region_details.csv

### DIFF
--- a/opentraveldata/optd_region_details.csv
+++ b/opentraveldata/optd_region_details.csv
@@ -253,7 +253,6 @@ UNWTO^PA^Pacific^^^Other Pacific^Antarctica^9100^55AQ^AQ
 UNWTO^PA^Pacific^^^Other Pacific^Other Pacific^6980^55OT^OT
 UNWTO^PA^Pacific^^^Polynesia^American Samoa^6510^54AS^AS
 UNWTO^PA^Pacific^^^Polynesia^Cook Islands^6520^54CK^CK
-UNWTO^PA^Pacific^^^Polynesia^Hawaii^6555^54HI^HI
 UNWTO^PA^Pacific^^^Polynesia^Niue^6610^54NU^NU
 UNWTO^PA^Pacific^^^Polynesia^French Polynesia (Tahiti)^6540 & 6670^54PF^PF
 UNWTO^PA^Pacific^^^Polynesia^Tokelau^6960^54TK^TK


### PR DESCRIPTION
Hawaii is wrongly defined as a country.Since Hawaii is a US state,deleting the entry where Hawaii is defined as a country.
